### PR TITLE
Add engine to Jekyll example

### DIFF
--- a/examples/jekyll/assemblefile.js
+++ b/examples/jekyll/assemblefile.js
@@ -7,6 +7,9 @@ var assemble = require('../..');
 var app = assemble();
 
 app.use(loader());
+
+app.engine(['hbs', 'md'], require('engine-handlebars') );
+
 app.create('layouts', {
   viewType: 'layout',
   renameKey: function (key) {


### PR DESCRIPTION
I get the following error when testing the Jekyll example:

`Error: Templates#render cannot find an engine for: .md`
